### PR TITLE
Added simple append and prepend slot

### DIFF
--- a/el-form-renderer.js
+++ b/el-form-renderer.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,87 @@
+import _defineProperty from 'babel-runtime/helpers/defineProperty';
+import _Object$keys from 'babel-runtime/core-js/object/keys';
+import _Object$assign from 'babel-runtime/core-js/object/assign';
+import RenderFormItem from './render-form-item';
+import RenderFormGroup from './render-form-group';
+import { Form } from 'element-ui';
+
+export default {
+  render: function render(h) {
+    var _this = this;
+
+    return h('el-form', {
+      props: _Object$assign({}, this._props, {
+        model: this.value // 用于校验
+      }),
+      ref: 'elForm'
+    }, this.content.map(function (item, index) {
+      // handle default value
+      if (item.$id && _this.value[item.$id] === undefined && item.$default !== undefined) {
+        _this.updateValue({ id: item.$id, value: item.$default });
+      }
+      var data = {
+        props: {
+          key: index,
+          data: item,
+          value: _this.value,
+          itemValue: _this.value[item.$id],
+          disabled: _this.disabled
+        },
+        on: {
+          updateValue: _this.updateValue
+        }
+      };
+      if (item.$type === 'group') return h('render-form-group', data);else return h('render-form-item', data);
+    }).concat(this.$slots.default));
+  },
+
+  components: {
+    RenderFormItem: RenderFormItem,
+    RenderFormGroup: RenderFormGroup
+  },
+  mounted: function mounted() {
+    var _this2 = this;
+
+    this.$nextTick(function () {
+      _Object$keys(Form.methods).forEach(function (item) {
+        _this2[item] = _this2.$refs.elForm[item];
+      });
+    });
+  },
+
+  props: _Object$assign({}, Form.props, {
+    content: {
+      type: Array,
+      required: true
+    },
+    // 禁用所有表单
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  }),
+  data: function data() {
+    return {
+      value: {} // 表单数据对象
+    };
+  },
+
+  methods: {
+    /**
+     * 更新表单数据
+     * @param  {String} options.id 表单ID
+     * @param  {All} options.value 表单数据
+     */
+    updateValue: function updateValue(_ref) {
+      var id = _ref.id,
+          value = _ref.value;
+
+      this.value = _Object$assign({}, this.value, _defineProperty({}, id, value));
+    },
+
+    // 对外提供获取表单数据的函数
+    getFormValue: function getFormValue() {
+      return this.value;
+    }
+  }
+};

--- a/lib/mixin-enable-when.js
+++ b/lib/mixin-enable-when.js
@@ -1,0 +1,50 @@
+/**
+ * 该 mixin 负责处理依赖属性 enableWhen 问题
+ */
+
+// 获取 value 对应 id 的配置值
+function getCurrentValue(value, id) {
+  return value && value[id];
+}
+
+export default {
+  methods: {
+    /**
+     * 处理 $enableWhen
+     *
+     * 与条件: 简单依赖关系存在2种情况：简单对象 || 字符串
+     * 或条件: 即使用 [] 包裹所有与条件 enableWhen: [{ a: 1 }, { a: 2 }]
+     */
+    getEnableWhenSatatus: function getEnableWhenSatatus() {
+      var _this = this;
+
+      var enableWhen = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this.data && this.data.$enableWhen;
+
+      // 处理一个与条件
+      var handlePlain = function handlePlain(enableWhen) {
+        // 简单字符串(ID), 只要有值即为true
+        if (typeof enableWhen === 'string') {
+          return getCurrentValue(_this.value, enableWhen) !== undefined;
+        }
+        // 简单对象判断: 是否所有依赖条件都通过
+        for (var id in enableWhen) {
+          if (enableWhen.hasOwnProperty(id)) {
+            var currentValue = getCurrentValue(_this.value, id);
+            if (currentValue === undefined || currentValue === '') return false;
+            if (!enableWhen[id] && currentValue === '') return false;
+            if (enableWhen[id] !== undefined && currentValue !== enableWhen[id]) return false;
+          }
+        }
+        return true;
+      };
+
+      if (enableWhen) {
+        return Array.isArray(enableWhen) ? enableWhen.some(function (item) {
+          return handlePlain(item);
+        }) : handlePlain(enableWhen);
+      } else {
+        return true;
+      }
+    }
+  }
+};

--- a/lib/mixin-package-option.js
+++ b/lib/mixin-package-option.js
@@ -1,0 +1,38 @@
+import _Object$assign from 'babel-runtime/core-js/object/assign';
+/**
+ * 扩展表单组件的 option 属性
+ */
+function controller(h, tag, props) {
+  return h(tag, {
+    props: props
+  });
+}
+
+function controllerVariation(h, tag, props) {
+  return h(tag, {
+    props: _Object$assign({}, props, {
+      key: props.value || props.label,
+      label: props.value || props.label
+    })
+  }, props.label);
+}
+
+export default {
+  methods: {
+    select_opt: function select_opt(item) {
+      return controller(this.$createElement, 'el-option', item);
+    },
+    radioGroup_opt: function radioGroup_opt(item) {
+      return controllerVariation(this.$createElement, 'el-radio', item);
+    },
+    radioButton_opt: function radioButton_opt(item) {
+      return controllerVariation(this.$createElement, 'el-radio-button', item);
+    },
+    checkboxGroup_opt: function checkboxGroup_opt(item) {
+      return controllerVariation(this.$createElement, 'el-checkbox', item);
+    },
+    checkboxButton_opt: function checkboxButton_opt(item) {
+      return controllerVariation(this.$createElement, 'el-checkbox-button', item);
+    }
+  }
+};

--- a/lib/render-form-group.js
+++ b/lib/render-form-group.js
@@ -1,0 +1,43 @@
+import _defineProperty from 'babel-runtime/helpers/defineProperty';
+import _Object$assign from 'babel-runtime/core-js/object/assign';
+import ElFormItemRenderer from './render-form-item';
+
+export default {
+  components: {
+    ElFormItemRenderer: ElFormItemRenderer
+  },
+  props: {
+    data: Object,
+    itemValue: {},
+    value: Object,
+    disabled: Boolean
+  },
+  render: function render(h) {
+    var _this = this;
+
+    return h('div', {}, this.data.$items.map(function (item, index) {
+      var itemValue = _this.itemValue || {};
+      return h('el-form-item-renderer', {
+        props: {
+          key: index,
+          data: item,
+          value: _this.value,
+          itemValue: itemValue[item.$id],
+          disabled: _this.disabled
+        },
+        on: {
+          updateValue: function updateValue(_ref) {
+            var id = _ref.id,
+                value = _ref.value;
+
+            var val = _Object$assign({}, itemValue, _defineProperty({}, id, value));
+            _this.$emit('updateValue', {
+              id: _this.data.$id,
+              value: val
+            });
+          }
+        }
+      });
+    }));
+  }
+};

--- a/lib/render-form-item.js
+++ b/lib/render-form-item.js
@@ -1,0 +1,85 @@
+import _Object$assign from 'babel-runtime/core-js/object/assign';
+import mixinOptionExtensions from './mixin-package-option';
+import mixinEnableWhen from './mixin-enable-when';
+import { toCamelCase, isObject } from './utils';
+
+function validator(data) {
+  if (!data) {
+    throw new Error('item data must be an Object.');
+  } else if (!data.$id) {
+    throw new Error('item $id is unvalidated.');
+  } else if (!data.$type) {
+    throw new Error('item $type is unvalidated.');
+  }
+}
+
+export default {
+  mixins: [mixinOptionExtensions, mixinEnableWhen],
+  props: {
+    data: Object,
+    itemValue: {},
+    value: Object,
+    disabled: Boolean
+  },
+  computed: {
+    // 是否显示
+    _show: function _show() {
+      return this.getEnableWhenSatatus();
+    }
+  },
+  render: function render(h) {
+    validator(this.data); // 对数据进行简单校验
+    return h('el-form-item', {
+      props: {
+        prop: this.data.$id,
+        label: this.data.label,
+        rules: this._show && Array.isArray(this.data.rules) ? this.data.rules : []
+      },
+      attrs: this.data.$attrs,
+      style: !this._show ? 'display: none;' : '' // 使用 v-show 减少 dom 操作
+    }, [this.renderFormItemContent(h, this.data, this.itemValue)]);
+  },
+
+  methods: {
+    /**
+     * 渲染表单项的内容
+     * @param  {Object} data 表单属性定义
+     * @param  {All} value 单项表单数据值
+     */
+    renderFormItemContent: function renderFormItemContent(h, data, value) {
+      var _this = this;
+
+      var obj = isObject(data.$el) ? data.$el : {};
+      var elType = data.$type === 'checkbox-button' ? 'checkbox-group' : data.$type;
+      var props = _Object$assign({}, obj, { value: value });
+      this.disabled && (props.disabled = this.disabled); // 只能全局禁用, false时不处理
+      var childElements = [];
+      var valid = ['append', 'prepend'];
+
+      valid.forEach(function (e) {
+        if (obj[e]) {
+          childElements.push(h('span', { slot: e }, [obj[e]]));
+        }
+      });
+
+      childElements.push(function () {
+        var optRenderer = _this[toCamelCase(data.$type) + '_opt'];
+        if (typeof optRenderer === 'function' && Array.isArray(data.$options)) {
+          return data.$options.map(optRenderer);
+        }
+      }());
+
+      childElements = childElements.filter(Boolean);
+
+      return h('el-' + elType, {
+        props: props,
+        on: {
+          // 手动更新表单数据
+          input: function input(value) {
+            _this.$emit('updateValue', { id: data.$id, value: value });
+          }
+        }
+      }, childElements);
+    }
+  }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,23 @@
+/**
+ * 转换为大小驼峰命名
+ * abc-efg => abcEfg
+ */
+export var toCamelCase = function toCamelCase(str) {
+  return str.indexOf('-') !== -1 ? str.replace(/-([a-zA-Z])/g, function ($0, $1) {
+    return $1.toUpperCase();
+  }) : str;
+};
+
+/**
+ * 首字母大写, 其他不变
+ */
+export var toUpperCaseFirst = function toUpperCaseFirst(str) {
+  return str[0].toUpperCase() + str.substr(1);
+};
+
+/**
+ * 是否对象
+ */
+export var isObject = function isObject(obj) {
+  return Object.prototype.toString.call(obj) === '[object Object]';
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "el-form-renderer",
-  "version": "1.0.2",
+  "version": "1.0.2-a",
   "description": "A Vue.js project",
   "author": "leezng <leezng@outlook.com>",
   "main": "el-form-renderer.js",

--- a/src/render-form-item.js
+++ b/src/render-form-item.js
@@ -71,7 +71,7 @@ export default {
           }
         })())
 
-      childElements = childElements.filter(Boolean);
+      childElements = childElements.filter(Boolean)
 
       return h('el-' + elType, {
         props: props,

--- a/src/render-form-item.js
+++ b/src/render-form-item.js
@@ -54,6 +54,25 @@ export default {
       let elType = data.$type === 'checkbox-button' ? 'checkbox-group' : data.$type
       let props = Object.assign({}, obj, { value })
       this.disabled && (props.disabled = this.disabled) // 只能全局禁用, false时不处理
+      let childElements = []
+      const valid = ['append', 'prepend']
+
+      valid.forEach(e => {
+        if (obj[e]) {
+          childElements.push(h('span', { slot: e }, [obj[e]]))
+        }
+      })
+
+      childElements.push(
+        (() => {
+          let optRenderer = this[`${toCamelCase(data.$type)}_opt`]
+          if (typeof optRenderer === 'function' && Array.isArray(data.$options)) {
+            return data.$options.map(optRenderer)
+          }
+        })())
+
+      childElements = childElements.filter(Boolean);
+
       return h('el-' + elType, {
         props: props,
         on: {
@@ -62,14 +81,7 @@ export default {
             this.$emit('updateValue', { id: data.$id, value })
           }
         }
-      }, [
-        (() => {
-          let optRenderer = this[`${toCamelCase(data.$type)}_opt`]
-          if (typeof optRenderer === 'function' && Array.isArray(data.$options)) {
-            return data.$options.map(optRenderer)
-          }
-        })()
-      ])
+      }, childElements)
     }
   }
 }


### PR DESCRIPTION
We needed to put some `append` and `prepend` to our inputs but i cannot find a way to do it so we updated the code to accommodate it
![image](https://user-images.githubusercontent.com/3828145/39713184-6f7ba7ce-5258-11e8-9d7f-abdebd7ae4c4.png)

*How to Use*
- Just add `append: 'something'` and/or `prepend: 'something'` to the `$el` property of your form

From:
```javascript
{
    $type: 'input',
    $id: 'height',
    label: 'Height',
    rules: [{
        required: true,
        message: 'Please input height (e.g. 160)',
        trigger: 'blur',
    }],
}
```

To:
```javascript
{
    $type: 'input',
    $id: 'height',
    $el: {
        prepend: 'Some Prepend',
        append: 'ft.',
    },
    label: 'Height',
    rules: [{
        required: true,
        message: 'Please input height (e.g. 160)',
        trigger: 'blur',
    }],
}
```

If this is already supported, please close the PR and point me to the right direction.
